### PR TITLE
Add DSL for workflows

### DIFF
--- a/src/wfrcwflib/file.py
+++ b/src/wfrcwflib/file.py
@@ -14,6 +14,7 @@ class SuffixedFiletype(Filetype):
         fps = list(dir.iterdir())
         for fp in fps:
             if fp.endswith(self.suffix):
+                yield fp
                 
 
 @dataclass

--- a/src/wfrcwflib/parse.py
+++ b/src/wfrcwflib/parse.py
@@ -1,0 +1,133 @@
+from wfrcwflib.workflow import (
+    Step, PositionalArgument, OptionalArgument,
+    InputConnector, OutputConnector
+)
+
+class ParseError(Exception):
+    pass
+
+def next_token(line):
+    toks = line.split(maxsplit=1)
+    match len(toks):
+        case 0:
+            return ("", "")
+        case 1:
+            return (toks[0], "")
+        case _:
+            return tuple(toks)
+
+connectors = {
+    "input": InputConnector,
+    "output": OutputConnector,
+}
+
+def parse_connector(line):
+    connector_open, rest = next_token(line)
+    if not connector_open == "{":
+        raise ParseError("connector must start with '{ '")
+
+    cmd, rest = next_token(rest)
+    if not cmd in connectors:
+        raise ParseError("invalid connector type")
+    cls = connectors[cmd]
+
+    name, rest = next_token(rest)
+    if not name:
+        raise ParseError("connector name cannot be empty")
+
+    ext, rest = next_token(rest)
+    if not ext:
+        raise ParseError("connector ext cannot be empty")
+
+    connector_close, rest = next_token(rest)
+    if not connector_close == "}":
+        raise ParseError("connector must end with ' }'")
+
+    return cls(name, ext), rest
+
+def parse_argument_value(line):
+    if line.startswith("{"):
+        return parse_connector(line)
+    else:
+        return next_token(line)
+
+def parse_positional_argument(line):
+    value, rest = parse_argument_value(line)
+    if rest:
+        raise ParseError("only one positional argument per line")
+    return PositionalArgument(value)
+
+def parse_optional_argument(line):
+    flag, rest = next_token(line)
+    if not flag.startswith("-"):
+        raise ParseError("optional argument flags must start with '-'")
+    obj = OptionalArgument(flag)
+    while rest:
+        value, rest = parse_argument_value(rest)
+        obj.values.append(value)
+    return obj
+
+def parse_step(lines):
+    lines = iter(lines)
+
+    name, name_rest = next_token(next(lines))
+    if name_rest:
+        raise ParseError("name must appear by itself")
+
+    prog, prog_rest = next_token(next(lines))
+    if prog_rest:
+        raise ParseError("prog must appear by itself")
+
+    obj = Step(name, prog)
+    for line in lines:
+        if line.startswith("-"):
+            arg = parse_optional_argument(line)
+        else:
+            arg = parse_positional_argument(line)
+        obj.args.append(arg)
+    return obj
+
+subparsers = {
+    "step": parse_step,
+}
+
+def parse_paragraph(lines):
+    lines = list(lines)
+    cmd, rest = next_token(lines[0])
+    if not cmd in subparsers:
+        raise ParseError("invalid keyword")
+    subparser = subparsers[cmd]
+    # Remove the command from the first line to avoid dealing with it later
+    lines[0] = rest
+    obj = subparser(lines)
+    return obj
+
+def split_paragraphs(lines):
+    paragraph = []
+    for line in lines:
+        if line:
+            paragraph.append(line)
+        elif paragraph:
+            yield paragraph
+            paragraph = []
+    if paragraph:
+        yield paragraph
+
+def parse(lines):
+    paragraphs = split_paragraphs(lines)
+    for p in paragraphs:
+        obj = parse_paragraph(p)
+        yield obj
+
+def strip_comment(line):
+    code, _, comment = line.partition("#")
+    return code
+
+def strip_whitespace(line):
+    return line.strip()
+
+def preprocess(lines):
+    for line in lines:
+        line = strip_comment(line)
+        line = strip_whitespace(line)
+        yield line

--- a/src/wfrcwflib/state.py
+++ b/src/wfrcwflib/state.py
@@ -1,0 +1,48 @@
+from dataclasses import dataclass
+from typing import Optional, Callable
+
+class State:
+    pass
+
+@dataclass
+class KeywordState(State):
+    name: str
+    transitions: list[State]
+    terminal: bool = False
+    
+    def check(self, tok):
+        tok == self.name
+
+@dataclass
+class RegexState(State):
+    name: str
+    pattern: str
+    transitions: list[State]
+    terminal: bool = False
+
+    def check(self, tok):
+        re.match(self.pattern, tok)
+
+
+s_step_option_value = RegexState("value", ".+", [s_step_option_value, s_step_argument_sep])
+s_step_option_flag = RegexState("flag", "-", [s_step_option_value, s_step_argument_sep])
+s_step_argument_sep = KeywordState("\n", [s_step_option_flag], terminal = True)
+s_step_resource = RegexState("resource", ".+", [s_step_argument_sep])
+s_step_name_sep = KeywordState("\n", [s_step_resource])
+s_step_name = RegexState("name", "[a-z][a-z_]", [s_step_name_sep]) 
+s_step = KeywordState("step", [s_step_name])
+s_init = KeywordState("init", [s_step])
+
+class WFSM:
+    def __init__(self):
+        state = s_init
+
+    def consume(self, tok):
+        next = self.next_state(tok)
+        
+    def next_state(self, tok):
+        for s in self.state.transitions:
+            if s.check(tok):
+                return s
+        return None
+            

--- a/src/wfrcwflib/test/test_parse.py
+++ b/src/wfrcwflib/test/test_parse.py
@@ -1,0 +1,134 @@
+import pytest
+
+from wfrcwflib.parse import (
+    ParseError,
+    split_paragraphs, next_token,
+    parse_connector, parse_argument_value,
+    parse_positional_argument, parse_optional_argument,
+    parse_step, parse_paragraph, parse,
+    strip_comment, preprocess,
+)
+from wfrcwflib.workflow import (
+    InputConnector, OutputConnector,
+    PositionalArgument, OptionalArgument,
+    Step,
+)
+
+def test_next_token():
+    # We assume that leading and trailing whitespace is removed
+    assert next_token("a bc d") == ("a", "bc d")
+    assert next_token("abc") == ("abc", "")
+    assert next_token("ab   cd") == ("ab", "cd")
+    assert next_token("") == ("", "")
+
+def test_parse_connector():
+    assert parse_connector("{ input a b }") == \
+        (InputConnector("a", "b"), "")
+    assert parse_connector("{ output 1 . } g-- -f") == \
+        (OutputConnector("1", "."), "g-- -f")
+    with pytest.raises(ParseError):
+        parse_connector("{input a b}")
+
+def test_parse_argument_value():
+    assert parse_argument_value("great.txt { input a b }") == \
+        ("great.txt", "{ input a b }")
+    assert parse_argument_value("{ input a b } great.txt") == \
+        (InputConnector("a", "b"), "great.txt")
+
+def test_parse_positional_argument():
+    assert parse_positional_argument("myfile.txt") == \
+        PositionalArgument("myfile.txt")
+    assert parse_positional_argument("{ input a b }") == \
+        PositionalArgument(InputConnector("a", "b"))
+    with pytest.raises(ParseError):
+        parse_positional_argument("myfile.txt b")
+
+def test_parse_optional_argument():
+    assert parse_optional_argument("-b") == OptionalArgument("-b")
+    assert parse_optional_argument("--hello there c") == \
+        OptionalArgument("--hello", ["there", "c"])
+
+blast_step = Step("blastn-mydb", "blastn", [
+    OptionalArgument("-query", [InputConnector("seqs", "fasta")]),
+    OptionalArgument("-db", ["myblastdb"]),
+    OptionalArgument("-out", [OutputConnector("result", "tsv")]),
+])
+
+def test_parse_step():
+    p = [
+        "blastn-mydb",
+        "blastn",
+        "-query { input seqs fasta }",
+        "-db myblastdb",
+        "-out { output result tsv }",
+    ]
+    assert parse_step(p) == blast_step
+
+def test_parse_paragraph():
+    p = [
+        "step blastn-mydb",
+        "blastn",
+        "-query { input seqs fasta }",
+        "-db myblastdb",
+        "-out { output result tsv }",
+    ]
+    assert parse_paragraph(p) == blast_step
+
+def test_split_paragraphs():
+    assert list(split_paragraphs(["a", "b", "", "c", "d"])) == \
+        [["a", "b"], ["c", "d"]]
+    assert list(split_paragraphs(["a", "", "c", "", ""])) == \
+        [["a"], ["c"]]
+    assert list(split_paragraphs(["a", "", "", "", "c", "d"])) == \
+        [["a"], ["c", "d"]]
+
+def test_parse():
+    input = [
+        "step a",
+        "b",
+        "--c d ef",
+        "g",
+        "",
+        "step h",
+        "ijk.py",
+        "{ input m n }",
+        ]
+    assert list(parse(input)) == [
+        Step("a", "b", [
+            OptionalArgument("--c", ["d", "ef"]),
+            PositionalArgument("g"),
+        ]),
+        Step("h", "ijk.py", [
+            PositionalArgument(InputConnector("m", "n")),
+        ]),
+    ]
+
+def test_strip_comment():
+    assert strip_comment("  code and  # comment") == "  code and  "
+
+code_with_extras = """\
+step a # very important
+  blastn
+  -query seqs.fasta
+  -db mydb.fasta
+  -out blastres.tsv
+
+# next step
+step b
+  myscript.R
+  blastres.tsv
+""".splitlines()
+
+def test_preprocess():
+    assert list(preprocess(code_with_extras)) == [
+        "step a",
+        "blastn",
+        "-query seqs.fasta",
+        "-db mydb.fasta",
+        "-out blastres.tsv",
+        "",
+        "",
+        "step b",
+        "myscript.R",
+        "blastres.tsv",
+    ]

--- a/src/wfrcwflib/workflow.py
+++ b/src/wfrcwflib/workflow.py
@@ -2,8 +2,6 @@ from dataclasses import dataclass, field
 from typing import Optional
 import graphlib
 
-import networkx as nx
-
 
 @dataclass
 class Connector:
@@ -33,7 +31,7 @@ class PositionalArgument:
 @dataclass
 class OptionalArgument:
     flag: str
-    values: list[str | Connector]
+    values: list[str | Connector] = field(default_factory=list)
 
     @property
     def inputs(self):

--- a/src/wfrcwflib/workflow.py
+++ b/src/wfrcwflib/workflow.py
@@ -55,41 +55,42 @@ class Step:
     def inputs(self):
         for arg in self.args:
             for input in arg.inputs:
-                yield input.name
+                yield input
 
     @property
     def outputs(self):
         for arg in self.args:
             for output in arg.outputs:
-                yield output.name
+                yield output
+
 
 class Workflow:
-    def __init__(self, step):
-        self.steps = {}
+    def __init__(self, available_steps):
+        self.available_steps = {step.name: step for step in available_steps}
+        self._active_steps = set()
+        # Reverse directed graph
+        # (step, input) => (step, output)
         self.connections_in = {}
-        # The first step in the workflow has no connections
-        self.add_step(step, {})
 
-    def add_step(self, step, connections):
-        """Add a step to the workflow
+    def connect(self, from_step, from_output, to_step, to_input):
+        self._add_step(from_step)
+        self._add_step(to_step)
+        self.connections_in[(to_step, to_input)] = (from_step, from_output)
 
-        Inputs of the step to be added are connected to outputs of a
-        previous step.  The input of a step can only be connected to
-        one output. As a result, the data model for `connections` is a
-        dict: input => (prev_step, output).
-        """
-        self.steps[step.name] = step
-        for input in step.inputs:
-            self.connections_in[(step.name, input)] = None
-        for input, (prev_step, output) in connections.items():
-            self.connections_in[(step.name, input)] = (prev_step, output)
+    def _add_step(self, step_name):
+        if step_name not in self._active_steps:
+            step = self.available_steps[step_name]
+            for input in step.inputs:
+                self.connections_in[(step.name, input.name)] = None
+            self._active_steps.add(step.name)
 
     @property
     def connections_out(self):
         res = {}
-        for step in self.steps.values():
+        for step_name in self._active_steps:
+            step = self.available_steps[step_name]
             for output in step.outputs:
-                res[(step.name, output)] = []
+                res[(step.name, output.name)] = []
         for k, v in self.connections_in.items():
             if v is not None:
                 res[v].append(k)
@@ -109,7 +110,7 @@ class Workflow:
 
     @property
     def dag(self):
-        graph = {step: set() for step in self.steps.keys()}
+        graph = {step: set() for step in self._active_steps}
         for dest, src in self.connections_in.items():
             print("Making DAG:", dest, src)
             if src is not None:

--- a/trywfr.py
+++ b/trywfr.py
@@ -25,14 +25,14 @@ c2 = Step("copy_2", "cp")
 c2.args.append(PositionalArgument(InputConnector("source", ".txt")))
 c2.args.append(PositionalArgument(OutputConnector("dest", ".config")))
 
-w = Workflow(c1)
+w = Workflow([c1, c2])
 print(list(w.inputs))
 print(list(w.outputs))
 
-w.add_step(c2, {"source": ("copy_1", "dest")})
+w.connect("copy_1", "dest", "copy_2", "source")
 print("Connections in:", w.connections_in)
 print("Inputs:", list(w.inputs))
-print("Connections out:", w.connections_out)      
+print("Connections out:", w.connections_out)
 print("Outputs:", list(w.outputs))
 
 print(w.dag)

--- a/trywfr.py
+++ b/trywfr.py
@@ -57,13 +57,13 @@ print(registry["paired-fastq"])
 
 # step copy_1
 #   cp
-#   {input source toml}
-#   {output dest txt}
+#   { input source toml }
+#   { output dest txt }
 
 # step copy_2
 #   cp
-#   {input source txt}
-#   {output dest config}
+#   { input source txt }
+#   { output dest config }
 
 # workflow double_copy
 #   copy_1 dest -> copy_2 source


### PR DESCRIPTION
Basic DSL for wfrcwf.

- Comments can be included with a # character. We don't yet support #'s inside code.
- The `preprocess()` function removes comments and strips all leading/trailing whitespace. As a consequence, users can indent however they want. We don't yet support spaces inside tokens (but this should be easy to add in the future).
- After preprocessing, the `parser()` function produces a stream of workflow objects. Only `Step` objects are supported in this initial implementation. The parser functions builds the objects directly; there is no intermediate data structure like a parse tree or AST.
- The parsing code uses as few restrictions as possible. For example, step names can't be empty but they can contain anything but whitespace. We may decide to add some restrictions in the future.
- Parsing errors raise a `ParseError` exception. Messages are basic and don't yet print out the current line or indicate the position of the parser.
- Users have to add space around the opening/closing braces when they make input or output connectors. This makes the tokenizer code much more straightforward.

That's it! There are some basic DSL examples in the tests.